### PR TITLE
Add HACS validation GitHub Action

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,19 @@
+name: Validate
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  validate-hacs:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: HACS validation
+        uses: "hacs/action@main"
+        with:
+          category: "plugin"


### PR DESCRIPTION
Add the HACS validation workflow required for submitting this repository to HACS. This workflow:
- Runs on push, pull requests, and daily via cron schedule
- Validates the repository as a plugin (custom card)
- Can be manually triggered via workflow_dispatch

This is a prerequisite for submitting the repository to the HACS default repository.